### PR TITLE
Ignore dlls (windows build) and .vscode (editor)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,12 +49,14 @@ map_extract
 map_replace_image
 map_resave
 map_version
+mastersrv
 packetgen
 testrunner
 tileset_borderadd
 tileset_borderfix
 tileset_borderrem
 tileset_borderset
+twping
 unicode_confusables
 uuid
 versionsrv
@@ -62,8 +64,10 @@ versionsrv
 generated
 
 .cproject
+.idea
 .project
 .settings
+.vscode
 cscope.files
 cscope.out
 
@@ -73,6 +77,7 @@ cscope.out
 /objs
 
 *.cmd
+*.dll
 *.dmg
 *.dtb
 *.exe


### PR DESCRIPTION
Now you can happily use ``git add .`` agian without tracking garbage :)